### PR TITLE
Ensure origMethod and methodMissing are called with target as context.

### DIFF
--- a/src/MethodMissingClass.js
+++ b/src/MethodMissingClass.js
@@ -14,14 +14,14 @@ export default class MethodMissingClass {
       const isFunction = typeof origMethod === "function";
       return isFunction
         ? function(...args) {
-            return origMethod(...args);
+            return origMethod.call(target, ...args);
           }
         : target[name];
     }
 
     // If the method doesn't exist, call methodMissing.
     return function(...args) {
-      return this.methodMissing(name, ...args);
+      return this.methodMissing.call(target, name, ...args);
     };
   }
 

--- a/src/WithMethodMissing.js
+++ b/src/WithMethodMissing.js
@@ -16,14 +16,14 @@ export default function withMethodMissing(originalClass) {
         const isFunction = typeof origMethod === "function";
         return isFunction
           ? function(...args) {
-              return origMethod(...args);
+              return origMethod.call(target, ...args);
             }
           : target[name];
       }
 
       // If the method doesn't exist, call methodMissing.
       return function(...args) {
-        return this.methodMissing(name, ...args);
+        return this.methodMissing.call(target, name, ...args);
       };
     }
   };


### PR DESCRIPTION
Currently the `this` context within a decorated or extended class method is `undefined`. PR ensures instance methods use proxy target as context.

**Example:**
```javascript
class Example extends MethodMissingClass {
    constructor( opts ){
      super()
      this.opts = opts
    }

    methodExisting(){
        console.log('this:', this)
        console.log('this.opts:', this.opts)
    }

    methodMissing(name, ...args) {
        console.log('this:', this)
        console.log('this.opts:', this.opts)
    }
}

const instance = new Example;
instance.methodExisting()
// > undefined > TypeError: Cannot read property 'opts' of undefined

instance.methodNone('prop');
// > undefined > TypeError: Cannot read property 'opts' of undefined
```

PR fixes the above. `this` now correctly refers to the instance of Example within `methodExisting` and `methodMissing` and therefore `this.opts` can be accessed in both.

 Let me know if there is anything else needed to have these updates pulled in. Thanks for the library, cheers.